### PR TITLE
Update 2018-05-06-Plaid2018-macsh.md

### DIFF
--- a/_posts/2018-05-06-Plaid2018-macsh.md
+++ b/_posts/2018-05-06-Plaid2018-macsh.md
@@ -59,7 +59,7 @@ Blocks:
 41dcdffb5e9cfbd12c15182b3fc5ea70
 {% endhighlight %}
 
-This throws a bit of a wrench in our gears: If we tag GOOD|PRIV, because its length will be different than GOOD, the extra blocks will not be the same, meaning we cannot just 'snip out' the good part. We need the length to be the same. Let's try that:
+This throws a bit of a wrench in our gears: If we tag `GOOD|PRIV`, because its length will be different than `GOOD`, the extra blocks will not be the same, meaning we cannot just 'snip out' the good part. We need the length to be the same. Let's try that:
 
 {% highlight bash %}
 |$|> <|>tag echo aaaaaaaaaaacat ././flag.txt


### PR DESCRIPTION
Fixed `|` problem

![9miqgdy](https://user-images.githubusercontent.com/18270655/39818476-4a8b23aa-53a1-11e8-9307-a6c817f47346.png)
